### PR TITLE
(#3) feat: add backup retention settings and UI improvements

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -125,6 +125,7 @@ code, .mono {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex: 1;
 }
 .action-bar-right {
   display: flex;
@@ -532,6 +533,7 @@ td:nth-child(2) {
 }
 
 input[type="text"],
+input[type="number"],
 textarea {
   width: 100%;
   padding: 10px 14px;
@@ -546,6 +548,7 @@ textarea {
   outline: none;
 }
 input[type="text"]:focus,
+input[type="number"]:focus,
 textarea:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px rgba(37,99,235,0.1);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,16 @@
 import { app, BrowserWindow, shell } from 'electron';
 import { join } from 'path';
 import { setupIpcHandlers } from './ipc';
+import { configService } from './services/config.service';
+import { initCrontabService } from './services/crontab.service';
 
 const isDev = process.env.NODE_ENV === 'development';
+
+// Initialize services
+async function initializeServices() {
+  await configService.load();
+  initCrontabService(configService);
+}
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -50,7 +58,8 @@ function createWindow() {
 }
 
 // App lifecycle
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  await initializeServices();
   createWindow();
 
   app.on('activate', () => {

--- a/src/main/services/config.service.ts
+++ b/src/main/services/config.service.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface BackupConfig {
+  maxBackups: number;
+  maxBackupDays: number;
+}
+
+export interface AppConfig {
+  backup: BackupConfig;
+}
+
+const DEFAULT_CONFIG: AppConfig = {
+  backup: {
+    maxBackups: 10,
+    maxBackupDays: 7,
+  },
+};
+
+export class ConfigService {
+  private configPath: string;
+  private config: AppConfig;
+
+  constructor() {
+    this.configPath = path.join(os.homedir(), '.cron-manager', 'config.json');
+    this.config = DEFAULT_CONFIG;
+  }
+
+  /**
+   * Load configuration from file
+   */
+  async load(): Promise<AppConfig> {
+    try {
+      if (await fs.pathExists(this.configPath)) {
+        const data = await fs.readJson(this.configPath);
+        this.config = { ...DEFAULT_CONFIG, ...data };
+      } else {
+        // Create default config file
+        await this.save(DEFAULT_CONFIG);
+      }
+    } catch (error) {
+      console.error('Failed to load config:', error);
+      this.config = DEFAULT_CONFIG;
+    }
+    return this.config;
+  }
+
+  /**
+   * Save configuration to file
+   */
+  async save(config: AppConfig): Promise<void> {
+    try {
+      await fs.ensureDir(path.dirname(this.configPath));
+      await fs.writeJson(this.configPath, config, { spaces: 2 });
+      this.config = config;
+    } catch (error) {
+      console.error('Failed to save config:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get current configuration
+   */
+  getConfig(): AppConfig {
+    return this.config;
+  }
+
+  /**
+   * Get backup configuration
+   */
+  getBackupConfig(): BackupConfig {
+    return this.config.backup;
+  }
+
+  /**
+   * Update backup configuration
+   */
+  async updateBackupConfig(backupConfig: Partial<BackupConfig>): Promise<void> {
+    this.config.backup = { ...this.config.backup, ...backupConfig };
+    await this.save(this.config);
+  }
+}
+
+// Export singleton
+export const configService = new ConfigService();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -65,6 +65,12 @@ const api = {
 
     create: (logPath: string): Promise<IpcResponse<void>> =>
       ipcRenderer.invoke('logs:create', logPath),
+
+    checkDir: (logPath?: string, workingDir?: string): Promise<IpcResponse<{ exists: boolean; dir: string }>> =>
+      ipcRenderer.invoke('logs:checkDir', logPath, workingDir),
+
+    createDir: (logPath?: string, workingDir?: string): Promise<IpcResponse<{ dir: string }>> =>
+      ipcRenderer.invoke('logs:createDir', logPath, workingDir),
   },
 
   // Files API
@@ -107,6 +113,15 @@ const api = {
 
     deleteGlobalVar: (key: string): Promise<IpcResponse<GlobalEnv>> =>
       ipcRenderer.invoke('env:deleteGlobalVar', key),
+  },
+
+  // Config API
+  config: {
+    getBackupConfig: (): Promise<IpcResponse<{ maxBackups: number; maxBackupDays: number }>> =>
+      ipcRenderer.invoke('config:getBackupConfig'),
+
+    updateBackupConfig: (maxBackups: number, maxBackupDays: number): Promise<IpcResponse<void>> =>
+      ipcRenderer.invoke('config:updateBackupConfig', maxBackups, maxBackupDays),
   },
 };
 


### PR DESCRIPTION
## Summary
Adds configurable backup retention settings and various UI improvements.

## Changes
- **ConfigService**: New service for managing backup retention policy
  - Configurable max backup count (default: 10)
  - Configurable max retention days (default: 7)
  - Persists to `~/.cron-manager/config.json`

- **Auto Cleanup**: Old backups cleaned up when settings saved
  - Triggers immediately on config save
  - Respects retention policy (keep minimum count, delete old)
  - Auto-refreshes backup list in UI

- **UI Improvements**:
  - Wider search input field (flex: 6)
  - Consistent styling for `input[type="number"]`
  - Backup settings section with save button

- **Command Trimming**: Auto-trim whitespace on job create/update

## Test Plan
- [x] Backup retention settings UI renders correctly
- [x] Settings save and persist across app restarts
- [x] Old backups cleaned up based on policy
- [x] Search input width increased
- [x] Number inputs styled consistently
- [x] Command whitespace trimmed on save

Closes #3