### PR TITLE
(#25) fix: prevent duplicate backup creation when content unchanged

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cron-manager",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Crontab Manager - Electron Desktop App",
   "main": "dist-electron/main/index.js",
   "author": {

--- a/src/main/services/crontab.service.ts
+++ b/src/main/services/crontab.service.ts
@@ -128,8 +128,14 @@ export class CrontabService {
     const os = await import('os');
     const path = await import('path');
 
-    // Backup current crontab before writing
-    await this.backupCrontab();
+    // Check if content has changed before creating backup
+    const currentContent = await this.readCrontab();
+    const hasChanged = currentContent.trim() !== content.trim();
+
+    // Only backup if content has actually changed
+    if (hasChanged) {
+      await this.backupCrontab();
+    }
 
     // Create secure temporary directory
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crontab-'));


### PR DESCRIPTION
## Summary

Fixes #25 

Backup files were being created every second even when crontab content hadn't changed.

## Changes

- Added content comparison before creating backup in `writeContab` method
- Only create backup when content has actually changed (after trimming whitespace)
- Bump version to 0.7.13

## Testing

- ✅ Verify backups are only created when crontab content actually changes
- ✅ Verify permission checks don't create unnecessary backups
- ✅ Verify auto-sync doesn't create unnecessary backups

## Impact

Prevents backup file spam from:
- Auto-sync on app startup
- Permission checks (dummy writes)
- Any other no-op crontab writes

Closes #25