### PR TITLE
(#27) feat: use user timezone for backup timestamps and allow 0-day retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ All releases are automatically built and published via GitHub Actions.
 
 **Method 2: Remove quarantine attribute (Terminal)**
 ```bash
-sudo xattr -rd com.apple.quarantine "/Applications/Cron Manager.app"
+🚨 sudo xattr -rd com.apple.quarantine "/Applications/Cron Manager.app"
 ```
 Enter your password when prompted, then launch the app normally.
 

--- a/frontend/src/components/BackupManager.tsx
+++ b/frontend/src/components/BackupManager.tsx
@@ -92,7 +92,7 @@ export function BackupManager() {
       showAlert(t('errors.minBackups'), 'error');
       return;
     }
-    if (maxBackupDays < 1) {
+    if (maxBackupDays < 0) {
       showAlert(t('errors.minDays'), 'error');
       return;
     }
@@ -291,8 +291,8 @@ export function BackupManager() {
             <input
               type="number"
               value={maxBackupDays}
-              onChange={(e) => setMaxBackupDays(Math.max(1, parseInt(e.target.value) || 1))}
-              min="1"
+              onChange={(e) => setMaxBackupDays(Math.max(0, parseInt(e.target.value) || 0))}
+              min="0"
               style={{ width: '100%' }}
             />
             <span style={{ fontSize: '12px', color: 'var(--text-tertiary)', marginTop: '4px', display: 'block' }}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cron-manager",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "Crontab Manager - Electron Desktop App",
   "main": "dist-electron/main/index.js",
   "author": {

--- a/src/main/services/crontab.service.ts
+++ b/src/main/services/crontab.service.ts
@@ -74,13 +74,20 @@ export class CrontabService {
       const backupDir = path.join(os.homedir(), '.cron-manager', 'backups');
       await fs.ensureDir(backupDir);
 
-      // Create backup file with timestamp (KST/UTC+9 in ISO 8601 format)
+      // Create backup file with timestamp in user's local timezone
       const now = new Date();
-      const kstOffset = 9 * 60; // KST is UTC+9
-      const kstDate = new Date(now.getTime() + kstOffset * 60 * 1000);
-      const isoString = kstDate.toISOString();
-      // Format: YYYY-MM-DDThh:mm:ss+09:00 (ISO 8601 with KST timezone)
-      const timestamp = isoString.slice(0, 19) + '+09:00';
+      const year = now.getFullYear();
+      const month = String(now.getMonth() + 1).padStart(2, '0');
+      const day = String(now.getDate()).padStart(2, '0');
+      const hours = String(now.getHours()).padStart(2, '0');
+      const minutes = String(now.getMinutes()).padStart(2, '0');
+      const seconds = String(now.getSeconds()).padStart(2, '0');
+      const timezoneOffset = -now.getTimezoneOffset(); // Minutes from UTC
+      const offsetHours = String(Math.floor(Math.abs(timezoneOffset) / 60)).padStart(2, '0');
+      const offsetMinutes = String(Math.abs(timezoneOffset) % 60).padStart(2, '0');
+      const offsetSign = timezoneOffset >= 0 ? '+' : '-';
+      // Format: YYYY-MM-DDThh-mm-ss+hh-mm (using hyphens for filesystem compatibility)
+      const timestamp = `${year}-${month}-${day}T${hours}-${minutes}-${seconds}${offsetSign}${offsetHours}-${offsetMinutes}`;
       const backupFile = path.join(backupDir, `crontab-${timestamp}.bak`);
       await fs.writeFile(backupFile, currentCrontab);
 


### PR DESCRIPTION
## Summary

Fixes #27

### Changes

1. **User Timezone for Backup Timestamps**
   - Changed from hardcoded KST (UTC+9) to user's local timezone
   - Format: `YYYY-MM-DDThh-mm-ss±hh-mm` (filesystem-safe)
   - Examples:
     - KST user: `crontab-2026-02-15T22-30-45+09-00.bak`
     - PST user: `crontab-2026-02-15T05-30-45-08-00.bak`

2. **Allow 0-Day Backup Retention**
   - `maxBackupDays` minimum changed from 1 to 0
   - 0 means: delete backups older than current time immediately
   - Useful for keeping only the most recent N backups

3. **README Enhancement**
   - Added 🚨 emoji to quarantine removal command for better visibility

### Files Modified

- `src/main/services/crontab.service.ts`: User timezone timestamp
- `frontend/src/components/BackupManager.tsx`: 0-day retention support
- `README.md`: Emphasize quarantine command
- `package.json`: Bump to v0.7.14

### Testing

- ✅ Backup timestamps match user's local timezone
- ✅ 0-day retention works correctly
- ✅ Backup creation/cleanup works as expected

Closes #27