### PR TITLE
(#39) fix: remove unused DragState type causing CI build failure

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,6 @@ const api = window.electronAPI;
 type SortField = 'name' | 'schedule' | 'command' | 'enabled' | 'nextRun' | 'id';
 type SortDirection = 'asc' | 'desc';
 type TabType = 'jobs' | 'env' | 'backups';
-type DragState = { index: number } | null;
 
 // LogButton component - checks if directory exists and shows appropriate button
 function LogButton({ logFile, workingDir, showAlert }: { logFile: string; workingDir?: string; showAlert: (message: string, type: 'info' | 'success' | 'error' | 'warning') => void }) {


### PR DESCRIPTION
## Summary
- Remove unused `DragState` type alias in `App.tsx` that causes `TS6196` build error in CI

## Test plan
- [x] `tsc --noEmit` passes locally
- [ ] CI build passes on all platforms

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)