### PR TITLE
(#41) fix: sync package.json version from git tag in CI build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -52,6 +52,13 @@ jobs:
           cd frontend
           npm ci
 
+      - name: Sync version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          npm version "$TAG_VERSION" --no-git-tag-version --allow-same-version
+
       - name: Build application
         run: npm run build:dev
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cron-manager",
-  "version": "0.9.0",
+  "version": "0.10.1",
   "description": "Crontab Manager - Electron Desktop App",
   "main": "dist-electron/main/index.js",
   "author": {


### PR DESCRIPTION
## Summary
- Bump package.json version to 0.10.1
- Add CI step to auto-sync package.json version from git tag before electron-builder runs
- Prevents mismatch between electron-builder output directory and artifact upload paths

## Root Cause
electron-builder uses `package.json` version for output directory (`release/0.9.0/`), but CI expected the tag version (`release/0.10.1/`). Artifacts were never uploaded, causing the release job to fail.

## Test plan
- [ ] CI build passes on all 3 platforms (macOS, Windows, Ubuntu)
- [ ] Release job successfully downloads artifacts and creates release

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)