### PR TITLE
Auto-save sort order after sync

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -147,6 +147,7 @@ function App() {
       const response = await api.jobs.getAll();
       if (response.success && response.data) {
         setJobs(response.data);
+        return response.data;
       } else {
         showAlert(response.error || t('errors.loadJobsFailed'), 'error');
       }
@@ -155,12 +156,17 @@ function App() {
     } finally {
       setLoading(false);
     }
+    return null;
   }, [showAlert, t]);
 
   const handleSync = useCallback(async (showSuccessAlert: boolean = true) => {
     try {
       await api.jobs.sync();
-      await fetchJobs();
+      const fetchedJobs = await fetchJobs();
+      if (fetchedJobs) {
+        const jobIds = fetchedJobs.map((job: CronJob) => job.id);
+        await api.jobs.reorder(jobIds);
+      }
       if (showSuccessAlert) {
         showAlert(t('success.syncCompleted'), 'success');
       }


### PR DESCRIPTION
## Summary
- Automatically save sort order (reorder) after sync completes, so users don't need to manually click save after syncing

Closes #43

## Test plan
- [x] Type check passes (`npm run type-check`)
- [x] All frontend tests pass (157 tests)
- [ ] Manual test: click sync button and verify sort order is auto-saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)