### PR TITLE
(#45) feat: add Windows WSL support for crontab management

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -17,6 +17,24 @@ export function setupIpcHandlers() {
     }
   });
 
+  ipcMain.handle('jobs:checkWslCronStatus', async () => {
+    try {
+      const result = await crontabService.checkWslCronStatus();
+      return { success: true, data: result };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('jobs:startWslCron', async () => {
+    try {
+      const result = await crontabService.startWslCron();
+      return { success: true, data: result };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  });
+
   ipcMain.handle('jobs:getAll', async () => {
     try {
       const jobs = await crontabService.getAllJobs();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -18,8 +18,14 @@ export interface IpcResponse<T = any> {
 const api = {
   // Jobs API
   jobs: {
-    checkPermission: (): Promise<IpcResponse<{ hasPermission: boolean; error?: string }>> =>
+    checkPermission: (): Promise<IpcResponse<{ hasPermission: boolean; cronRunning?: boolean; error?: string }>> =>
       ipcRenderer.invoke('jobs:checkPermission'),
+
+    checkWslCronStatus: (): Promise<IpcResponse<{ running: boolean; error?: string }>> =>
+      ipcRenderer.invoke('jobs:checkWslCronStatus'),
+
+    startWslCron: (): Promise<IpcResponse<{ success: boolean; error?: string }>> =>
+      ipcRenderer.invoke('jobs:startWslCron'),
 
     getAll: (): Promise<IpcResponse<CronJob[]>> =>
       ipcRenderer.invoke('jobs:getAll'),


### PR DESCRIPTION
## Summary

- Refactor platform-specific logic into helpers (`isWindows`, `cronCmd`, `toWslPath`)
- Use `wsl crontab` commands on Windows for read/write/restore operations
- Add `checkWslAvailable()`, `checkWslCronStatus()`, `startWslCron()` methods
- Include `cronRunning` in `checkPermission()` response on Windows
- Add IPC handlers: `jobs:checkWslCronStatus`, `jobs:startWslCron`
- Show warning banner + "Start cron" button when WSL cron daemon is not running

## Test plan

- [ ] macOS: existing crontab behavior unchanged
- [ ] Windows + WSL installed: reads/writes WSL crontab correctly
- [ ] Windows + WSL not installed: shows WSL install error message
- [ ] Windows + WSL cron stopped: shows warning banner with Start cron button
- [ ] Clicking "Start cron": starts daemon and banner disappears

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)