### PR TITLE
(#47) feat: in-app log viewer + Windows/WSL compatibility fixes

### DIFF
--- a/frontend/src/components/BackupManager.tsx
+++ b/frontend/src/components/BackupManager.tsx
@@ -6,6 +6,7 @@ import { useResizableColumns } from '../hooks/useResizableColumns';
 import { format } from 'date-fns';
 import { useAlertDialog } from './AlertDialog';
 import { ConfirmDialog } from './ConfirmDialog';
+import { modKey } from '../utils/platform';
 
 const api = window.electronAPI;
 
@@ -263,7 +264,7 @@ export function BackupManager() {
             ) : (
               <>
                 <Save size={16} />
-                {t('common.save')} <span style={{ opacity: 0.6, fontSize: '11px' }}>(⌘S)</span>
+                {t('common.save')} <span style={{ opacity: 0.6, fontSize: '11px' }}>({modKey}S)</span>
               </>
             )}
           </button>

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+
+const api = window.electronAPI;
+
+interface LogViewerProps {
+  logPath: string;
+  workingDir?: string;
+  onClose: () => void;
+}
+
+export function LogViewer({ logPath, workingDir, onClose }: LogViewerProps) {
+  const [lines, setLines] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setLines([]);
+    setError(null);
+
+    api.logs.startStream(logPath, workingDir);
+
+    const offData = api.logs.onData((chunk: string) => {
+      const newLines = chunk.split('\n').filter((l: string) => l !== '');
+      setLines((prev) => [...prev, ...newLines]);
+    });
+
+    const offError = api.logs.onError((err: string) => {
+      setError(err);
+    });
+
+    const offClose = api.logs.onClose(() => {
+      setError('Stream closed.');
+    });
+
+    return () => {
+      api.logs.stopStream();
+      offData();
+      offError();
+      offClose();
+    };
+  }, [logPath, workingDir]);
+
+  useEffect(() => {
+    if (autoScroll && bottomRef.current) {
+      bottomRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [lines, autoScroll]);
+
+  const handleScroll = () => {
+    const el = contentRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    setAutoScroll(atBottom);
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.6)',
+        zIndex: 1000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        style={{
+          background: '#0d1117',
+          borderRadius: '8px',
+          width: '80vw',
+          height: '70vh',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '10px 16px',
+            background: '#161b22',
+            borderBottom: '1px solid #30363d',
+            flexShrink: 0,
+          }}
+        >
+          <span style={{ fontFamily: 'monospace', fontSize: '13px', color: '#8b949e' }}>
+            tail -f <span style={{ color: '#e6edf3' }}>{logPath}</span>
+          </span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px', color: '#8b949e', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={autoScroll}
+                onChange={(e) => setAutoScroll(e.target.checked)}
+                style={{ cursor: 'pointer' }}
+              />
+              Auto-scroll
+            </label>
+            <button
+              onClick={onClose}
+              style={{ background: 'none', border: 'none', color: '#8b949e', cursor: 'pointer', padding: '2px', display: 'flex' }}
+            >
+              <X size={16} />
+            </button>
+          </div>
+        </div>
+
+        {/* Log content */}
+        <div
+          ref={contentRef}
+          onScroll={handleScroll}
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            padding: '12px 16px',
+            fontFamily: 'monospace',
+            fontSize: '12px',
+            lineHeight: '1.6',
+            color: '#e6edf3',
+          }}
+        >
+          {lines.length === 0 && !error && (
+            <span style={{ color: '#8b949e' }}>Waiting for log output…</span>
+          )}
+          {lines.map((line, i) => (
+            <div key={i} style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+              {line}
+            </div>
+          ))}
+          {error && (
+            <div style={{ color: '#f85149', marginTop: '8px' }}>{error}</div>
+          )}
+          <div ref={bottomRef} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/utils/platform.ts
+++ b/frontend/src/utils/platform.ts
@@ -1,0 +1,4 @@
+export const isMac = navigator.platform.toUpperCase().includes('MAC');
+
+/** Modifier key prefix for display: '⌘' on macOS, 'Ctrl+' on Windows/Linux */
+export const modKey = isMac ? '⌘' : 'Ctrl+';

--- a/src/main/services/crontab.service.ts
+++ b/src/main/services/crontab.service.ts
@@ -621,7 +621,7 @@ export class CrontabService {
     const globalEnv = await this.getGlobalEnv();
     const mergedEnv = {
       // Minimal essential vars from process
-      PATH: process.env.PATH || '/usr/bin:/bin',
+      PATH: process.env.PATH || (this.isWindows ? 'C:\\Windows\\System32' : '/usr/bin:/bin'),
       // Global env from crontab
       ...globalEnv,
       // Job-specific env (highest priority)
@@ -656,7 +656,7 @@ export class CrontabService {
       if (job.logFile) {
         try {
           const fs = await import('fs/promises');
-          const logPath = job.logFile.replace(/^~/, process.env.HOME || '');
+          const logPath = job.logFile.replace(/^~/, process.env.HOME || process.env.USERPROFILE || '');
           await fs.access(logPath);
           logFileExists = true;
         } catch {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -69,8 +69,28 @@ const api = {
 
   // Logs API
   logs: {
-    open: (logPath?: string, workingDir?: string): Promise<IpcResponse<void>> =>
-      ipcRenderer.invoke('logs:open', logPath, workingDir),
+    startStream: (logPath: string, workingDir?: string): Promise<IpcResponse<void>> =>
+      ipcRenderer.invoke('logs:startStream', logPath, workingDir),
+
+    stopStream: (): Promise<IpcResponse<void>> =>
+      ipcRenderer.invoke('logs:stopStream'),
+
+    onData: (callback: (data: string) => void) => {
+      const handler = (_: unknown, data: string) => callback(data);
+      ipcRenderer.on('logs:data', handler);
+      return () => ipcRenderer.removeListener('logs:data', handler);
+    },
+
+    onError: (callback: (err: string) => void) => {
+      const handler = (_: unknown, err: string) => callback(err);
+      ipcRenderer.on('logs:error', handler);
+      return () => ipcRenderer.removeListener('logs:error', handler);
+    },
+
+    onClose: (callback: () => void) => {
+      ipcRenderer.on('logs:closed', callback);
+      return () => ipcRenderer.removeListener('logs:closed', callback);
+    },
 
     create: (logPath: string): Promise<IpcResponse<void>> =>
       ipcRenderer.invoke('logs:create', logPath),


### PR DESCRIPTION
## Summary

- Real-time in-app log viewer replacing macOS-only osascript terminal
- Full Windows/WSL path and env compatibility fixes

## Changes

### In-app Log Viewer
- \`logs:startStream\` / \`logs:stopStream\` IPC — uses \`tail -f\` (Unix) or \`wsl tail -f\` (Windows/WSL paths)
- \`LogViewer\` component: dark terminal modal, real-time streaming, auto-scroll toggle
- \`LogButton\` opens in-app viewer instead of external Terminal app

### Platform / WSL Fixes
- \`validateLogPath\`: WSL paths (\`~\`/\`/\`) pass through on Windows without Windows path resolution; platform-aware forbidden paths; \`path.sep\` instead of hardcoded \`/\`
- \`crontab.service.ts\`: platform-aware \`PATH\` fallback; \`USERPROFILE\` fallback for home dir on Windows
- \`platform.ts\`: shared \`modKey\` (\`⌘\` on macOS, \`Ctrl+\` on Windows/Linux) used across App.tsx and BackupManager.tsx

## Test plan

- [ ] macOS: log button opens in-app viewer, streams correctly
- [ ] Windows + WSL: log button streams via \`wsl tail -f\`
- [ ] Auto-scroll follows new log lines; unchecking stops following
- [ ] Closing viewer stops the stream
- [ ] Keyboard shortcuts show \`Ctrl+\` on Windows/Linux, \`⌘\` on macOS

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)