### PR TITLE
(#49) fix: refresh nextRun every 10s and on scheduled time expiry

### DIFF
--- a/frontend/src/components/NextRunCell.tsx
+++ b/frontend/src/components/NextRunCell.tsx
@@ -3,9 +3,10 @@ import { format } from 'date-fns';
 
 interface NextRunCellProps {
   nextRun: string | null;
+  onExpired?: () => void;
 }
 
-export function NextRunCell({ nextRun }: NextRunCellProps) {
+export function NextRunCell({ nextRun, onExpired }: NextRunCellProps) {
   const [timeLeft, setTimeLeft] = useState<string>('');
   const [urgencyClass, setUrgencyClass] = useState<string>('');
   const [urgencyColor, setUrgencyColor] = useState<string>('');
@@ -23,8 +24,17 @@ export function NextRunCell({ nextRun }: NextRunCellProps) {
       const target = new Date(nextRun).getTime();
       const diff = target - now;
 
-      // If time has passed or more than 5 minutes away, show normal date format
-      if (diff < 0 || diff > 5 * 60 * 1000) {
+      // If time has passed, notify parent to recalculate nextRun
+      if (diff < 0) {
+        setTimeLeft(format(new Date(nextRun), 'yyyy-MM-dd HH:mm:ss'));
+        setUrgencyClass('');
+        setUrgencyColor('');
+        onExpired?.();
+        return false; // Stop interval
+      }
+
+      // More than 5 minutes away, show normal date format
+      if (diff > 5 * 60 * 1000) {
         setTimeLeft(format(new Date(nextRun), 'yyyy-MM-dd HH:mm:ss'));
         setUrgencyClass('');
         setUrgencyColor('');


### PR DESCRIPTION
## Summary

- `NextRunCell` shows a static date after the scheduled time passes — never updates
- Add 10-second periodic silent refresh so nextRun stays current
- Add immediate refresh when a job's scheduled time expires

## Changes

- `App.tsx`: `silentRefreshNextRuns` — re-fetches jobs without loading spinner
- `App.tsx`: `setInterval(silentRefreshNextRuns, 10_000)` with cleanup
- `NextRunCell.tsx`: `onExpired?: () => void` prop — called when `diff < 0`

## Test plan

- [ ] nextRun updates every ~10 seconds automatically
- [ ] When a job's scheduled time passes, nextRun immediately recalculates to next occurrence
- [ ] No loading spinner flash during silent refresh

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)