### PR TITLE
(#51) feat: detachable log viewer windows and manual run output in log file

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,6 @@ import { Play, Trash2, Plus, RefreshCw, FolderOpen, FileText, Edit, ChevronUp, C
 import { JobForm } from './components/JobForm';
 import { GlobalEnvSettings } from './components/GlobalEnvSettings';
 import { BackupManager } from './components/BackupManager';
-import { LogViewer } from './components/LogViewer';
 import { useAlertDialog } from './components/AlertDialog';
 import { NextRunCell } from './components/NextRunCell';
 import type { CronJob, CreateJobRequest, UpdateJobRequest } from '@cron-manager/shared';
@@ -114,7 +113,6 @@ function App() {
   const [jobDragOverIndex, setJobDragOverIndex] = useState<number | null>(null);
   const [wslCronRunning, setWslCronRunning] = useState<boolean | null>(null);
   const [startingWslCron, setStartingWslCron] = useState(false);
-  const [logViewer, setLogViewer] = useState<{ logPath: string; workingDir?: string } | null>(null);
   const { showAlert } = useAlertDialog();
 
   // Resizable columns for jobs table
@@ -639,15 +637,6 @@ function App() {
 
   return (
     <div className="app">
-      {/* In-app log viewer */}
-      {logViewer && (
-        <LogViewer
-          logPath={logViewer.logPath}
-          workingDir={logViewer.workingDir}
-          onClose={() => setLogViewer(null)}
-        />
-      )}
-
       {/* WSL cron warning banner */}
       {wslCronRunning === false && (
         <div style={{
@@ -1184,7 +1173,7 @@ function App() {
                                       logFile={logFile}
                                       workingDir={job.workingDir}
                                       showAlert={showAlert}
-                                      onOpenLog={(logPath, wd) => setLogViewer({ logPath, workingDir: wd })}
+                                      onOpenLog={(logPath, wd) => { api.logs.openWindow(logPath, wd); }}
                                     />
                                   ))
                                 ) : (

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -19,6 +19,8 @@ global.window.electronAPI = {
     sync: vi.fn(),
     reorder: vi.fn(),
     checkPermission: vi.fn().mockResolvedValue({ success: true, data: { hasPermission: true } }),
+    checkWslCronStatus: vi.fn().mockResolvedValue({ success: true, data: { running: false } }),
+    startWslCron: vi.fn().mockResolvedValue({ success: true, data: { success: true } }),
     testIn1Minute: vi.fn(),
   },
   schedule: {
@@ -41,7 +43,12 @@ global.window.electronAPI = {
     updateBackupConfig: vi.fn(),
   },
   logs: {
-    open: vi.fn(),
+    openWindow: vi.fn(),
+    startStream: vi.fn(),
+    stopStream: vi.fn(),
+    onData: vi.fn().mockReturnValue(() => {}),
+    onError: vi.fn().mockReturnValue(() => {}),
+    onClose: vi.fn().mockReturnValue(() => {}),
     checkDir: vi.fn(),
     createDir: vi.fn(),
     create: vi.fn(),

--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -7,9 +7,10 @@ interface LogViewerProps {
   logPath: string;
   workingDir?: string;
   onClose: () => void;
+  fullScreen?: boolean;
 }
 
-export function LogViewer({ logPath, workingDir, onClose }: LogViewerProps) {
+export function LogViewer({ logPath, workingDir, onClose, fullScreen }: LogViewerProps) {
   const [lines, setLines] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [autoScroll, setAutoScroll] = useState(true);
@@ -56,6 +57,90 @@ export function LogViewer({ logPath, workingDir, onClose }: LogViewerProps) {
     setAutoScroll(atBottom);
   };
 
+  const header = (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '10px 16px',
+        background: '#161b22',
+        borderBottom: '1px solid #30363d',
+        flexShrink: 0,
+      }}
+    >
+      <span style={{ fontFamily: 'monospace', fontSize: '13px', color: '#8b949e' }}>
+        tail -f <span style={{ color: '#e6edf3' }}>{logPath}</span>
+      </span>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px', color: '#8b949e', cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={autoScroll}
+            onChange={(e) => setAutoScroll(e.target.checked)}
+            style={{ cursor: 'pointer' }}
+          />
+          Auto-scroll
+        </label>
+        <button
+          onClick={onClose}
+          style={{ background: 'none', border: 'none', color: '#8b949e', cursor: 'pointer', padding: '2px', display: 'flex' }}
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  );
+
+  const logContent = (
+    <div
+      ref={contentRef}
+      onScroll={handleScroll}
+      style={{
+        flex: 1,
+        overflowY: 'auto',
+        padding: '12px 16px',
+        fontFamily: 'monospace',
+        fontSize: '12px',
+        lineHeight: '1.6',
+        color: '#e6edf3',
+      }}
+    >
+      {lines.length === 0 && !error && (
+        <span style={{ color: '#8b949e' }}>Waiting for log output…</span>
+      )}
+      {lines.map((line, i) => (
+        <div key={i} style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+          {line}
+        </div>
+      ))}
+      {error && (
+        <div style={{ color: '#f85149', marginTop: '8px' }}>{error}</div>
+      )}
+      <div ref={bottomRef} />
+    </div>
+  );
+
+  // Full-screen mode: fill the entire OS window (used in detached log windows)
+  if (fullScreen) {
+    return (
+      <div
+        style={{
+          width: '100vw',
+          height: '100vh',
+          background: '#0d1117',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {header}
+        {logContent}
+      </div>
+    );
+  }
+
+  // Modal overlay mode (inline in App)
   return (
     <div
       style={{
@@ -81,67 +166,8 @@ export function LogViewer({ logPath, workingDir, onClose }: LogViewerProps) {
           boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
         }}
       >
-        {/* Header */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '10px 16px',
-            background: '#161b22',
-            borderBottom: '1px solid #30363d',
-            flexShrink: 0,
-          }}
-        >
-          <span style={{ fontFamily: 'monospace', fontSize: '13px', color: '#8b949e' }}>
-            tail -f <span style={{ color: '#e6edf3' }}>{logPath}</span>
-          </span>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-            <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px', color: '#8b949e', cursor: 'pointer' }}>
-              <input
-                type="checkbox"
-                checked={autoScroll}
-                onChange={(e) => setAutoScroll(e.target.checked)}
-                style={{ cursor: 'pointer' }}
-              />
-              Auto-scroll
-            </label>
-            <button
-              onClick={onClose}
-              style={{ background: 'none', border: 'none', color: '#8b949e', cursor: 'pointer', padding: '2px', display: 'flex' }}
-            >
-              <X size={16} />
-            </button>
-          </div>
-        </div>
-
-        {/* Log content */}
-        <div
-          ref={contentRef}
-          onScroll={handleScroll}
-          style={{
-            flex: 1,
-            overflowY: 'auto',
-            padding: '12px 16px',
-            fontFamily: 'monospace',
-            fontSize: '12px',
-            lineHeight: '1.6',
-            color: '#e6edf3',
-          }}
-        >
-          {lines.length === 0 && !error && (
-            <span style={{ color: '#8b949e' }}>Waiting for log output…</span>
-          )}
-          {lines.map((line, i) => (
-            <div key={i} style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-              {line}
-            </div>
-          ))}
-          {error && (
-            <div style={{ color: '#f85149', marginTop: '8px' }}>{error}</div>
-          )}
-          <div ref={bottomRef} />
-        </div>
+        {header}
+        {logContent}
       </div>
     </div>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -118,11 +118,11 @@ export const scheduleApi = {
 
 // Logs API
 export const logsApi = {
-  open: async (logPath?: string): Promise<void> => {
+  openWindow: async (logPath: string, workingDir?: string): Promise<void> => {
     if (!isElectron) {
       throw new Error('Electron API not available');
     }
-    await handleIpcResponse(window.electronAPI.logs.open(logPath));
+    await handleIpcResponse(window.electronAPI.logs.openWindow(logPath, workingDir));
   },
 
   create: async (logPath: string): Promise<void> => {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,9 +3,24 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import './i18n/config'
 import App from './App.tsx'
+import { LogViewer } from './components/LogViewer.tsx'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+const params = new URLSearchParams(window.location.search);
+const mode = params.get('mode');
+
+if (mode === 'logviewer') {
+  const logPath = params.get('logPath') || '';
+  const workingDir = params.get('workingDir') || undefined;
+
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <LogViewer logPath={logPath} workingDir={workingDir} onClose={() => window.close()} fullScreen />
+    </StrictMode>,
+  );
+} else {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -63,7 +63,7 @@ app.whenReady().then(async () => {
   await initializeServices();
 
   // Setup IPC handlers once when app is ready
-  setupIpcHandlers();
+  setupIpcHandlers({ htmlPath: isDev ? undefined : join(__dirname, '../../dist/index.html') });
 
   createWindow();
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -69,6 +69,9 @@ const api = {
 
   // Logs API
   logs: {
+    openWindow: (logPath: string, workingDir?: string): Promise<IpcResponse<void>> =>
+      ipcRenderer.invoke('logs:openWindow', logPath, workingDir),
+
     startStream: (logPath: string, workingDir?: string): Promise<IpcResponse<void>> =>
       ipcRenderer.invoke('logs:startStream', logPath, workingDir),
 


### PR DESCRIPTION
## Summary
- Open each log in its own Electron `BrowserWindow` via `logs:openWindow` IPC — multiple detachable windows now supported
- `frontend/src/main.tsx` detects `?mode=logviewer&logPath=...` query param and renders `<LogViewer>` fullscreen instead of `<App>`
- `runJob()` appends stdout/stderr with a timestamp header to `job.logFile` so manual Play runs are visible in the log viewer

## Test plan
- [ ] Click log button → new OS-level window opens showing `tail -f` output
- [ ] Open multiple log windows simultaneously (different jobs)
- [ ] Click Play on a job with a logFile → log viewer shows `[timestamp] Manual run` with stdout output
- [ ] `echo "test"` command output appears in log viewer after manual run
- [ ] All 157 tests pass

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)