### PR TITLE
(#53) fix: strip shell-escaped quotes from log paths in extractLogFiles

### DIFF
--- a/frontend/src/utils/logFileExtractor.ts
+++ b/frontend/src/utils/logFileExtractor.ts
@@ -11,7 +11,8 @@ export function extractLogFiles(command: string): string[] {
 
   let match;
   while ((match = redirectionRegex.exec(command)) !== null) {
-    const filePath = match[1].trim();
+    // Strip surrounding single/double quotes (from shellEscape)
+    const filePath = match[1].trim().replace(/^['"]|['"]$/g, '');
 
     // Skip special redirections like /dev/null, /dev/stdout, /dev/stderr
     if (!filePath.startsWith('/dev/')) {


### PR DESCRIPTION
## Summary
- `shellEscape()` wraps log paths in single quotes when serializing crontab lines (e.g., `'~/logs/test.log'`)
- `extractLogFiles()` regex captured the surrounding quotes, passing `'~/logs/test.log'` to `validateLogPath`
- `validateLogPath` doesn't recognize the `'` prefix, skips `~` expansion, resolves to a wrong absolute path
- `tail -f` streams an empty wrong file while actual log data goes to the correct expanded path

## Fix
One-line change: strip surrounding single/double quotes after regex extraction.

```ts
const filePath = match[1].trim().replace(/^['"]|['"]$/g, '');
```

## Test plan
- [ ] Job with `logFile = ~/logs/test.log` → click log button → log window shows correct file content
- [ ] Click Play → `[timestamp] Manual run` output appears in log window
- [ ] All 157 tests pass

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)