### PR TITLE
(#55) fix: WSL user display and tilde path expansion in crontab and log streaming

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -112,6 +112,7 @@ function App() {
   const [jobDragIndex, setJobDragIndex] = useState<number | null>(null);
   const [jobDragOverIndex, setJobDragOverIndex] = useState<number | null>(null);
   const [wslCronRunning, setWslCronRunning] = useState<boolean | null>(null);
+  const [wslUser, setWslUser] = useState<string | null>(null);
   const [startingWslCron, setStartingWslCron] = useState(false);
   const { showAlert } = useAlertDialog();
 
@@ -136,6 +137,11 @@ function App() {
         }
         if (response.data.cronRunning !== undefined) {
           setWslCronRunning(response.data.cronRunning);
+          // Fetch WSL user for display in the banner
+          const userRes = await api.jobs.getWslUser();
+          if (userRes.success && userRes.data) {
+            setWslUser(userRes.data);
+          }
         }
       }
     } catch (error) {
@@ -638,36 +644,42 @@ function App() {
   return (
     <div className="app">
       {/* WSL cron warning banner */}
-      {wslCronRunning === false && (
+      {wslCronRunning !== null && (
         <div style={{
-          background: '#7c3aed',
+          background: wslCronRunning ? '#1e3a5f' : '#7c3aed',
           color: '#fff',
-          padding: '8px 16px',
+          padding: '6px 16px',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
           fontSize: '13px',
           gap: '8px',
         }}>
-          <span>⚠️ WSL cron daemon is not running. Scheduled jobs will not execute.</span>
-          <button
-            onClick={handleStartWslCron}
-            disabled={startingWslCron}
-            style={{
-              background: '#fff',
-              color: '#7c3aed',
-              border: 'none',
-              borderRadius: '4px',
-              padding: '4px 12px',
-              cursor: startingWslCron ? 'not-allowed' : 'pointer',
-              fontWeight: 600,
-              fontSize: '12px',
-              whiteSpace: 'nowrap',
-              opacity: startingWslCron ? 0.7 : 1,
-            }}
-          >
-            {startingWslCron ? 'Starting…' : 'Start cron'}
-          </button>
+          <span>
+            {wslUser && <span style={{ opacity: 0.8, marginRight: '8px' }}>WSL user: <strong>{wslUser}</strong></span>}
+            {!wslCronRunning && '⚠️ WSL cron daemon is not running. Scheduled jobs will not execute.'}
+            {wslCronRunning && '✓ WSL cron daemon is running.'}
+          </span>
+          {!wslCronRunning && (
+            <button
+              onClick={handleStartWslCron}
+              disabled={startingWslCron}
+              style={{
+                background: '#fff',
+                color: '#7c3aed',
+                border: 'none',
+                borderRadius: '4px',
+                padding: '4px 12px',
+                cursor: startingWslCron ? 'not-allowed' : 'pointer',
+                fontWeight: 600,
+                fontSize: '12px',
+                whiteSpace: 'nowrap',
+                opacity: startingWslCron ? 0.7 : 1,
+              }}
+            >
+              {startingWslCron ? 'Starting…' : 'Start cron'}
+            </button>
+          )}
         </div>
       )}
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,6 +21,9 @@ const api = {
     checkPermission: (): Promise<IpcResponse<{ hasPermission: boolean; cronRunning?: boolean; error?: string }>> =>
       ipcRenderer.invoke('jobs:checkPermission'),
 
+    getWslUser: (): Promise<IpcResponse<string>> =>
+      ipcRenderer.invoke('jobs:getWslUser'),
+
     checkWslCronStatus: (): Promise<IpcResponse<{ running: boolean; error?: string }>> =>
       ipcRenderer.invoke('jobs:checkWslCronStatus'),
 


### PR DESCRIPTION
## Summary

- Add `shellEscapeForPath()` to preserve `~/` prefix unquoted so bash expands `~` correctly in crontab and log append
- Fix `logs:startStream` to pre-expand `~` via `getWslHome()` before passing path to `tail`
- Add `getWslHome()` / `getWslUser()` with caching; expose via `jobs:getWslUser` IPC and preload API
- Show WSL user identity in banner (both running and not-running states)
- Render "Start cron" button only when `wslCronRunning === false`

## Test plan

- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] All 157 tests pass (`npm test -- --run`)
- [ ] WSL cron banner shows correct WSL user
- [ ] "Start cron" button hidden when cron is already running
- [ ] Crontab lines with `~/logs/...` paths are written correctly (no single-quoted `~`)
- [ ] Log streaming works with `~/` paths

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)