### PR TITLE
(#57) fix: WSL log directory check/create and file creation before tail stream

### DIFF
--- a/docs/WIN.MD
+++ b/docs/WIN.MD
@@ -1,0 +1,26 @@
+# docs/WIN
+
+### `1. 앱이 사용하는 WSL 유저 확인`
+```bash
+wsl whoami
+```
+
+### `2. 실제 crontab 내용 확인`
+```bash
+wsl crontab -l
+```
+
+### `3. cron 데몬 실행 중인지 확인`
+```bash
+wsl service cron status
+```
+
+### `4. 로그 디렉토리 존재 여부`
+```bash
+wsl ls -la ~/logs/
+```
+
+### `5. WSL 로그 파일 존재 여부`
+```bash
+wsl ls -la ~/logs/
+```


### PR DESCRIPTION
## Summary

- `logs:checkDir`: WSL paths now checked via `wsl sh -c "test -d '...'"` instead of Windows `fs-extra` — the directory button now shows correct status
- `logs:createDir`: WSL paths now created via `wsl mkdir -p` instead of `fs-extra.ensureDir` — directory creation inside WSL actually works
- `logs:startStream`: WSL log file created via `wsl sh -c "mkdir -p ... && touch ..."` before spawning `tail -f` — log viewer no longer shows blank/closes immediately
- `docs/WIN.MD`: Added WSL debugging reference commands

## Test plan

- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] All 157 tests pass (`npm test -- --run`)
- [ ] "Create log directory" button correctly detects WSL `~/logs/` existence
- [ ] Clicking the button creates `~/logs/` inside WSL (verify with `wsl ls ~/logs/`)
- [ ] Log viewer opens and streams content (file is auto-created if missing)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)