### PR TITLE
(#59) fix: WSL executable folder open and log viewer stream error display

### DIFF
--- a/frontend/src/components/LogViewer.tsx
+++ b/frontend/src/components/LogViewer.tsx
@@ -21,8 +21,6 @@ export function LogViewer({ logPath, workingDir, onClose, fullScreen }: LogViewe
     setLines([]);
     setError(null);
 
-    api.logs.startStream(logPath, workingDir);
-
     const offData = api.logs.onData((chunk: string) => {
       const newLines = chunk.split('\n').filter((l: string) => l !== '');
       setLines((prev) => [...prev, ...newLines]);
@@ -34,6 +32,14 @@ export function LogViewer({ logPath, workingDir, onClose, fullScreen }: LogViewe
 
     const offClose = api.logs.onClose(() => {
       setError('Stream closed.');
+    });
+
+    api.logs.startStream(logPath, workingDir).then((res: any) => {
+      if (res && !res.success) {
+        setError(res.error || 'Failed to start log stream');
+      }
+    }).catch((err: any) => {
+      setError(err?.message || 'Failed to start log stream');
     });
 
     return () => {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -554,6 +554,17 @@ export function setupIpcHandlers(config?: { htmlPath?: string }) {
         return { success: false, error: 'File path must be absolute' };
       }
 
+      // On Windows, WSL paths (~/... or /...) must be converted via wslpath
+      if (process.platform === 'win32' && (filePath.startsWith('~') || filePath.startsWith('/'))) {
+        try {
+          const { stdout } = await execAsync(`wsl bash -c "wslpath -w $(dirname ${filePath})"`);
+          await shell.openPath(stdout.trim());
+        } catch {
+          return { success: false, error: 'Cannot open WSL path in Windows Explorer' };
+        }
+        return { success: true };
+      }
+
       // Get directory from file path
       let expandedFilePath = filePath;
       if (filePath.startsWith('~')) {


### PR DESCRIPTION
## Summary

- `files:open` (IPC): On Windows, WSL paths (`~/...` or `/...`) are now converted to Windows UNC paths via `wsl bash -c "wslpath -w $(dirname <path>)"` before calling `shell.openPath` — Windows Explorer now opens the correct WSL filesystem location
- `LogViewer.tsx`: Moved `onData`/`onError`/`onClose` listener registration before `startStream` call; chained `.then()/.catch()` on `startStream` to show init errors in the UI instead of silently showing "Waiting for log output..." forever

## Test plan

- [ ] TypeScript type check passes
- [ ] All 157 tests pass
- [ ] Clicking executable folder button opens WSL directory in Windows Explorer
- [ ] Log viewer shows error message immediately if stream fails to start
- [ ] Log viewer works normally when stream starts successfully

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)