### PR TITLE
(#61) fix: shell-escaped quotes in log paths prevent log viewer from opening correct file

### DIFF
--- a/frontend/src/__tests__/utils/logFileExtractor.test.ts
+++ b/frontend/src/__tests__/utils/logFileExtractor.test.ts
@@ -97,5 +97,24 @@ describe('logFileExtractor', () => {
       const result = extractLogFiles('');
       expect(result).toEqual([]);
     });
+
+    it('unescapes shell-quoted tilde paths (shellEscapeForPath output)', () => {
+      // shellEscapeForPath("~/logs/test.log") produces ~/'logs/test.log'
+      const command = "/usr/bin/test.sh >> ~/'logs/test.log' 2>&1";
+      const result = extractLogFiles(command);
+      expect(result).toEqual(['~/logs/test.log']);
+    });
+
+    it('unescapes fully single-quoted paths', () => {
+      const command = "/usr/bin/test.sh >> '/var/log/app.log'";
+      const result = extractLogFiles(command);
+      expect(result).toEqual(['/var/log/app.log']);
+    });
+
+    it('unescapes shell-quoted stderr path', () => {
+      const command = "/bin/job.sh >> ~/'logs/out.log' 2>> ~/'logs/err.log'";
+      const result = extractLogFiles(command);
+      expect(result).toEqual(['~/logs/out.log', '~/logs/err.log']);
+    });
   });
 });

--- a/frontend/src/utils/logFileExtractor.ts
+++ b/frontend/src/utils/logFileExtractor.ts
@@ -1,4 +1,32 @@
 /**
+ * Unescape a shell-escaped path.
+ * Handles single-quoted segments produced by shellEscapeForPath, e.g.:
+ *   ~/'logs/test.log'  →  ~/logs/test.log
+ *   '/var/log/app.log' →  /var/log/app.log
+ */
+function shellUnescapePath(str: string): string {
+  let result = '';
+  let i = 0;
+  while (i < str.length) {
+    if (str[i] === "'") {
+      // Find the closing single quote and extract the content
+      const end = str.indexOf("'", i + 1);
+      if (end === -1) {
+        // Unclosed quote: take remainder literally (minus the opening quote)
+        result += str.slice(i + 1);
+        break;
+      }
+      result += str.slice(i + 1, end);
+      i = end + 1;
+    } else {
+      result += str[i];
+      i++;
+    }
+  }
+  return result;
+}
+
+/**
  * Extract log file paths from command strings
  * Supports: >>, >, 2>>, 2>, &>
  */
@@ -11,8 +39,8 @@ export function extractLogFiles(command: string): string[] {
 
   let match;
   while ((match = redirectionRegex.exec(command)) !== null) {
-    // Strip surrounding single/double quotes (from shellEscape)
-    const filePath = match[1].trim().replace(/^['"]|['"]$/g, '');
+    // Unescape shell-quoted path segments (e.g. ~/'logs/test.log' → ~/logs/test.log)
+    const filePath = shellUnescapePath(match[1].trim());
 
     // Skip special redirections like /dev/null, /dev/stdout, /dev/stderr
     if (!filePath.startsWith('/dev/')) {


### PR DESCRIPTION
## Summary

- `extractLogFiles()` was stripping only leading/trailing quotes with `.replace(/^['"]|['"]$/g, '')`, but paths like `~/'logs/test.log'` have the quote at position 2 (not position 0), so the internal `'` was left in the path
- Replaced with `shellUnescapePath()` which iterates through the string and properly extracts content from `'...'` quoted segments
- Added 3 test cases covering shell-escaped tilde paths and fully-quoted paths

## Root cause trace

```
shellEscapeForPath("~/logs/test.log") → ~/'logs/test.log'   (in crontab)
extractLogFiles captures              → ~/'logs/test.log'
old .replace(/^['"]|['"]$/g, '')      → ~/'logs/test.log    (internal ' remains!)
expand ~                              → /home/user/'logs/test.log  (wrong file!)
tail -f → file not found → exits → log viewer shows nothing
```

## Test plan

- [ ] All 160 tests pass
- [ ] Log viewer opens and streams existing log file correctly
- [ ] `~/logs/test.log` path (after shell-escape in crontab) resolves to correct file

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)