### PR TITLE
(#69) fix: remove unused FolderPlus import causing build failure

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
-import { Play, Trash2, Plus, RefreshCw, FolderOpen, Edit, ChevronUp, ChevronDown, Save, ListChecks, Settings, Database, Search, X, FolderPlus, Github, Languages, Check, GripVertical } from 'lucide-react';
+import { Play, Trash2, Plus, RefreshCw, FolderOpen, Edit, ChevronUp, ChevronDown, Save, ListChecks, Settings, Database, Search, X, Github, Languages, Check, GripVertical } from 'lucide-react';
 import { JobForm } from './components/JobForm';
 import { LogButton } from './components/LogButton';
 import { GlobalEnvSettings } from './components/GlobalEnvSettings';


### PR DESCRIPTION
## Summary
- Remove unused `FolderPlus` import from `App.tsx`

## Root Cause
After extracting `LogButton` to a separate component in #68, `FolderPlus` was no longer used in `App.tsx` but the import remained, causing TypeScript build error: `TS6133: 'FolderPlus' is declared but its value is never read`.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)