### PR TITLE
(#71) feat: add update notice banner when new version is available

### DIFF
--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -56,6 +56,9 @@ global.window.electronAPI = {
   files: {
     open: vi.fn(),
   },
+  updates: {
+    check: vi.fn().mockResolvedValue({ success: true, data: { latestVersion: 'v0.15.1', releaseUrl: 'https://github.com/seunggabi/cron-manager/releases/tag/v0.15.1' } }),
+  },
 };
 
 // Mock localStorage with actual in-memory implementation

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -150,6 +150,10 @@
     "copyWslCmd": "WSL-Befehl kopieren",
     "copied": "Kopiert!"
   },
+  "updates": {
+    "available": "Neue Version {{version}} verfügbar!",
+    "download": "Herunterladen"
+  },
   "errors": {
     "createDirFailed": "Verzeichnis erstellen fehlgeschlagen",
     "loadJobsFailed": "Jobs laden fehlgeschlagen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -151,6 +151,10 @@
     "copyWslCmd": "Copy WSL Command",
     "copied": "Copied!"
   },
+  "updates": {
+    "available": "New version {{version}} is available!",
+    "download": "Download"
+  },
   "errors": {
     "crontabPermissionDenied": "Permission denied to access crontab. Please grant Full Disk Access permission in System Settings → Privacy & Security → Full Disk Access.",
     "createDirFailed": "Failed to create directory",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -150,6 +150,10 @@
     "copyWslCmd": "WSL कमांड कॉपी करें",
     "copied": "कॉपी किया!"
   },
+  "updates": {
+    "available": "नया संस्करण {{version}} उपलब्ध है!",
+    "download": "डाउनलोड"
+  },
   "errors": {
     "createDirFailed": "निर्देशिका बनाने में विफल",
     "loadJobsFailed": "कार्य लोड करने में विफल",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -150,6 +150,10 @@
     "copyWslCmd": "WSLコマンドをコピー",
     "copied": "コピー済み!"
   },
+  "updates": {
+    "available": "新しいバージョン {{version}} が利用可能です！",
+    "download": "ダウンロード"
+  },
   "errors": {
     "createDirFailed": "ディレクトリの作成に失敗しました",
     "loadJobsFailed": "ジョブの読み込みに失敗しました",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -151,6 +151,10 @@
     "copyWslCmd": "WSL 명령어 복사",
     "copied": "복사됨!"
   },
+  "updates": {
+    "available": "새 버전 {{version}}이 출시되었습니다!",
+    "download": "다운로드"
+  },
   "errors": {
     "crontabPermissionDenied": "crontab 접근 권한이 거부되었습니다. 시스템 설정 → 개인 정보 보호 및 보안 → 전체 디스크 접근 권한에서 권한을 부여해주세요.",
     "createDirFailed": "디렉토리 생성에 실패했습니다",

--- a/frontend/src/i18n/locales/pt-BR.json
+++ b/frontend/src/i18n/locales/pt-BR.json
@@ -150,6 +150,10 @@
     "copyWslCmd": "Copiar comando WSL",
     "copied": "Copiado!"
   },
+  "updates": {
+    "available": "Nova versão {{version}} disponível!",
+    "download": "Baixar"
+  },
   "errors": {
     "createDirFailed": "Falha ao criar diretório",
     "loadJobsFailed": "Falha ao carregar tarefas",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -150,6 +150,10 @@
     "copyWslCmd": "Скопировать команду WSL",
     "copied": "Скопировано!"
   },
+  "updates": {
+    "available": "Доступна новая версия {{version}}!",
+    "download": "Скачать"
+  },
   "errors": {
     "createDirFailed": "Не удалось создать директорию",
     "loadJobsFailed": "Не удалось загрузить задачи",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -150,6 +150,10 @@
     "copyWslCmd": "复制WSL命令",
     "copied": "已复制!"
   },
+  "updates": {
+    "available": "新版本 {{version}} 已发布！",
+    "download": "下载"
+  },
   "errors": {
     "createDirFailed": "创建目录失败",
     "loadJobsFailed": "加载任务失败",

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -158,6 +158,12 @@ const api = {
     updateBackupConfig: (maxBackups: number, maxBackupDays: number): Promise<IpcResponse<void>> =>
       ipcRenderer.invoke('config:updateBackupConfig', maxBackups, maxBackupDays),
   },
+
+  // Updates API
+  updates: {
+    check: (): Promise<IpcResponse<{ latestVersion: string; releaseUrl: string }>> =>
+      ipcRenderer.invoke('updates:check'),
+  },
 };
 
 // Expose the API to the renderer process


### PR DESCRIPTION
## Summary
- Check GitHub Releases API on app start to detect new versions
- Show sky-blue notice banner at top when newer version is available
- Banner includes download link and dismiss (X) button
- Added i18n keys (`updates.available`, `updates.download`) for all 8 languages

## Test plan
- [ ] App starts and silently checks for updates via GitHub API
- [ ] Banner appears when a newer version is available
- [ ] Clicking download link opens release page
- [ ] Clicking X dismisses the banner
- [ ] No banner shown when already on latest version

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)