### PR TITLE
(#73) fix: replace WSL log copy button with terminal open

### DIFF
--- a/frontend/src/__tests__/components/LogButton.test.tsx
+++ b/frontend/src/__tests__/components/LogButton.test.tsx
@@ -22,9 +22,9 @@ beforeEach(() => {
 // WSL 모드
 // ────────────────────────────────────────────────────────────
 describe('LogButton (WSL mode)', () => {
-  it('dirExists 체크 없이 즉시 복사 버튼을 렌더링한다', () => {
+  it('dirExists 체크 없이 즉시 logs.log 버튼을 렌더링한다', () => {
     render(<LogButton {...defaultProps} isWsl />);
-    expect(screen.getByText('logs.copyWslCmd')).toBeInTheDocument();
+    expect(screen.getByText('logs.log')).toBeInTheDocument();
   });
 
   it('checkDir API를 호출하지 않는다', () => {
@@ -32,60 +32,29 @@ describe('LogButton (WSL mode)', () => {
     expect(window.electronAPI.logs.checkDir).not.toHaveBeenCalled();
   });
 
-  it('title에 mkdir -p && touch && tail -f 형식의 명령어가 포함된다', () => {
+  it('title에 logFile 경로가 포함된다', () => {
     render(<LogButton {...defaultProps} logFile="~/logs/test.log" isWsl />);
-    const btn = screen.getByTitle(/mkdir -p.*touch.*tail -f/);
+    const btn = screen.getByTitle(/~/);
     expect(btn).toBeInTheDocument();
   });
 
-  it('logFile 경로에서 디렉토리를 올바르게 추출한다', () => {
-    render(<LogButton {...defaultProps} logFile="~/logs/app/test.log" isWsl />);
-    const btn = screen.getByTitle('mkdir -p ~/logs/app && touch ~/logs/app/test.log && tail -f ~/logs/app/test.log');
-    expect(btn).toBeInTheDocument();
-  });
-
-  it('슬래시가 없는 경로면 디렉토리를 ~로 처리한다', () => {
-    render(<LogButton {...defaultProps} logFile="test.log" isWsl />);
-    const btn = screen.getByTitle('mkdir -p ~ && touch test.log && tail -f test.log');
-    expect(btn).toBeInTheDocument();
-  });
-
-  it('클릭 시 올바른 명령어를 클립보드에 복사한다', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText } });
-
+  it('클릭 시 openWslTerminal API를 호출한다', async () => {
     render(<LogButton {...defaultProps} logFile="~/logs/test.log" isWsl />);
-    fireEvent.click(screen.getByText('logs.copyWslCmd'));
+    fireEvent.click(screen.getByText('logs.log'));
     await flushPromises();
 
-    expect(writeText).toHaveBeenCalledWith(
-      'mkdir -p ~/logs && touch ~/logs/test.log && tail -f ~/logs/test.log'
+    expect(window.electronAPI.logs.openWslTerminal).toHaveBeenCalledWith('~/logs/test.log');
+  });
+
+  it('openWslTerminal 실패 시 showAlert를 호출한다', async () => {
+    (window.electronAPI.logs.openWslTerminal as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Terminal error')
     );
-  });
-
-  it('복사 후 "logs.copied" 피드백 텍스트가 표시된다', async () => {
-    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
-
     render(<LogButton {...defaultProps} isWsl />);
-    fireEvent.click(screen.getByText('logs.copyWslCmd'));
+    fireEvent.click(screen.getByText('logs.log'));
     await flushPromises();
 
-    expect(screen.getByText('logs.copied')).toBeInTheDocument();
-  });
-
-  it('2초 후 복사 피드백이 사라지고 원래 텍스트로 돌아온다', async () => {
-    vi.useFakeTimers();
-    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
-
-    render(<LogButton {...defaultProps} isWsl />);
-    fireEvent.click(screen.getByText('logs.copyWslCmd'));
-    await flushPromises();
-    expect(screen.getByText('logs.copied')).toBeInTheDocument();
-
-    await act(async () => { vi.advanceTimersByTime(2000); });
-    expect(screen.getByText('logs.copyWslCmd')).toBeInTheDocument();
-
-    vi.useRealTimers();
+    expect(mockShowAlert).toHaveBeenCalledWith('errors.openFolderFailed', 'error');
   });
 });
 

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -52,6 +52,7 @@ global.window.electronAPI = {
     checkDir: vi.fn(),
     createDir: vi.fn(),
     create: vi.fn(),
+    openWslTerminal: vi.fn().mockResolvedValue({ success: true }),
   },
   files: {
     open: vi.fn(),

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -466,6 +466,33 @@ export function setupIpcHandlers(config?: { htmlPath?: string }) {
     }
   });
 
+  // Open WSL terminal with tail -f
+  ipcMain.handle('logs:openWslTerminal', async (_, logPath: string) => {
+    try {
+      let resolvedPath = logPath;
+      if (resolvedPath.startsWith('~')) {
+        try {
+          const wslHome = await crontabService.getWslHome();
+          resolvedPath = resolvedPath.replace(/^~/, wslHome);
+        } catch {
+          // keep original ~ if home detection fails
+        }
+      }
+      const logDir = resolvedPath.substring(0, resolvedPath.lastIndexOf('/'));
+      const cmd = `mkdir -p '${logDir}' && touch '${resolvedPath}' && tail -f '${resolvedPath}'`;
+
+      // Try Windows Terminal first, fallback to cmd.exe
+      exec(`wt.exe wsl.exe -e bash -c "${cmd}; exec bash"`, (err) => {
+        if (err) {
+          exec(`cmd.exe /c start wsl.exe bash -c "${cmd}; exec bash"`);
+        }
+      });
+      return { success: true };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  });
+
   // Stop log stream
   ipcMain.handle('logs:stopStream', async (event) => {
     const proc = activeTailProcesses.get(event.sender.id);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -106,6 +106,9 @@ const api = {
 
     createDir: (logPath?: string, workingDir?: string): Promise<IpcResponse<{ dir: string }>> =>
       ipcRenderer.invoke('logs:createDir', logPath, workingDir),
+
+    openWslTerminal: (logPath: string): Promise<IpcResponse<void>> =>
+      ipcRenderer.invoke('logs:openWslTerminal', logPath),
   },
 
   // Files API


### PR DESCRIPTION
## Summary
- Replace clipboard copy button with terminal open button in WSL log mode
- Add `logs:openWslTerminal` IPC handler: tries `wt.exe` first, falls back to `cmd.exe`
- Add `openWslTerminal` to preload API
- Update LogButton tests: WSL copy tests → terminal open tests

## Test plan
- [ ] WSL mode: clicking Log button opens Windows Terminal with `tail -f`
- [ ] Falls back to `cmd.exe /c start wsl.exe` if `wt.exe` unavailable
- [ ] Non-WSL mode: unchanged behavior
- [ ] All 174 tests pass

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)