### PR TITLE
(#75) fix: replace external log window with inline modal LogViewer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo, useCallback } from 'react';
 import { Play, Trash2, Plus, RefreshCw, FolderOpen, Edit, ChevronUp, ChevronDown, Save, ListChecks, Settings, Database, Search, X, Github, Languages, Check, GripVertical } from 'lucide-react';
 import { JobForm } from './components/JobForm';
 import { LogButton } from './components/LogButton';
+import { LogViewer } from './components/LogViewer';
 import { GlobalEnvSettings } from './components/GlobalEnvSettings';
 import { BackupManager } from './components/BackupManager';
 import { useAlertDialog } from './components/AlertDialog';
@@ -43,6 +44,7 @@ function App() {
   const [startingWslCron, setStartingWslCron] = useState(false);
   const [updateInfo, setUpdateInfo] = useState<{ latestVersion: string; releaseUrl: string } | null>(null);
   const [updateDismissed, setUpdateDismissed] = useState(false);
+  const [logViewer, setLogViewer] = useState<{ logPath: string; workingDir?: string } | null>(null);
   const { showAlert } = useAlertDialog();
 
   // Resizable columns for jobs table
@@ -1180,7 +1182,7 @@ function App() {
                                       logFile={logFile}
                                       workingDir={job.workingDir}
                                       showAlert={showAlert}
-                                      onOpenLog={(logPath, wd) => { api.logs.openWindow(logPath, wd); }}
+                                      onOpenLog={(logPath, wd) => { setLogViewer({ logPath, workingDir: wd }); }}
                                       isWsl={isWsl}
                                     />
                                   ))
@@ -1231,6 +1233,15 @@ function App() {
           job={editingJob}
           onClose={handleCloseForm}
           onSubmit={editingJob ? handleUpdate : handleCreate}
+        />
+      )}
+
+      {/* Log Viewer Modal */}
+      {logViewer && (
+        <LogViewer
+          logPath={logViewer.logPath}
+          workingDir={logViewer.workingDir}
+          onClose={() => setLogViewer(null)}
         />
       )}
     </div>

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -321,6 +321,7 @@ export function setupIpcHandlers(config?: { htmlPath?: string }) {
         width: 900,
         height: 650,
         title: `Log: ${path.basename(logPath)}`,
+        backgroundColor: '#0d1117',
         webPreferences: {
           preload: path.join(__dirname, '../../preload/index.js'),
           nodeIntegration: false,
@@ -479,7 +480,7 @@ export function setupIpcHandlers(config?: { htmlPath?: string }) {
         }
       }
       const logDir = resolvedPath.substring(0, resolvedPath.lastIndexOf('/'));
-      const cmd = `mkdir -p '${logDir}' && touch '${resolvedPath}' && tail -f '${resolvedPath}'`;
+      const cmd = `mkdir -p '${logDir}' && touch '${resolvedPath}' && tail -f -n 100 '${resolvedPath}'`;
 
       // Try Windows Terminal first, fallback to cmd.exe
       exec(`wt.exe wsl.exe -e bash -c "${cmd}; exec bash"`, (err) => {


### PR DESCRIPTION
## Summary
- Replace `api.logs.openWindow` call with inline modal `LogViewer` in App.tsx
- Log viewer now opens as an overlay modal within the app (no separate window)
- Add `logViewer` state to App.tsx to control modal visibility
- Add `tail -f -n 100` for WSL terminal command (shows last 100 lines on open)
- Add `backgroundColor: '#0d1117'` to BrowserWindow for future use

## Test plan
- [ ] Click Log button → LogViewer modal appears inside the app
- [ ] Click X or outside modal → modal closes
- [ ] Log stream displays correctly with auto-scroll
- [ ] WSL terminal opens with last 100 lines shown

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)