### PR TITLE
(#81) fix: prevent modal close on overlay click and change command field to textarea

### DIFF
--- a/frontend/src/components/JobForm.tsx
+++ b/frontend/src/components/JobForm.tsx
@@ -115,7 +115,7 @@ export function JobForm({ job, onClose, onSubmit }: JobFormProps) {
   ];
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay">
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h2>{job ? t('jobs.editJob') : t('jobs.newCronJob')}</h2>
@@ -179,13 +179,13 @@ export function JobForm({ job, onClose, onSubmit }: JobFormProps) {
               <label className="field-label">
                 {t('jobs.form.command')} <span className="required">{t('jobs.form.required')}</span>
               </label>
-              <input
-                type="text"
+              <textarea
                 value={command}
                 onChange={(e) => setCommand(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={t('jobs.form.commandPlaceholder')}
                 className="mono"
+                rows={3}
                 required
               />
             </div>


### PR DESCRIPTION
## Summary
- Remove `onClick` from modal overlay to prevent accidental form dismissal
- Change command input from `<input type="text">` to `<textarea rows={3}>` for multiline visibility

## Test plan
- [ ] Open new job form, click outside the modal → should NOT close
- [ ] Command field should display as multiline textarea (3 rows)
- [ ] ESC key and Cancel/X buttons still close the modal

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)