### PR TITLE
(#83) feat: show loading spinner on run button while job is executing

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -240,8 +240,15 @@ code, .mono {
 .icon-btn.edit:hover { background: var(--accent-light); color: var(--accent); }
 .icon-btn.pause:hover { background: var(--amber-bg); color: var(--amber); }
 .icon-btn.play:hover { background: var(--green-bg); color: var(--green); }
+.icon-btn.play.running { background: var(--green-bg); color: var(--green); cursor: not-allowed; opacity: 0.7; }
 .icon-btn.delete:hover { background: var(--red-bg); color: var(--red); }
 .icon-btn svg { width: 16px; height: 16px; }
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+.spin { animation: spin 1s linear infinite; }
 
 /* Table Card */
 .table-card {


### PR DESCRIPTION
## Summary
- Add `runningJobs: Set<string>` state to track which jobs are currently running
- Show animated `Loader2` spinner on the run button while the job executes
- Disable the button during execution to prevent duplicate triggers
- Restore button state in `finally` block (handles both success and error)

## Test plan
- [ ] Click run button → spinner appears and button is disabled
- [ ] Job completes → button returns to normal Play icon
- [ ] Multiple jobs can run simultaneously (each tracked independently)
- [ ] Error case also restores the button

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)