### PR TITLE
(#85) feat: add GitHub Star button with gh CLI integration

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -164,6 +164,15 @@ const api = {
     check: (): Promise<IpcResponse<{ latestVersion: string; releaseUrl: string }>> =>
       ipcRenderer.invoke('updates:check'),
   },
+
+  // GitHub API
+  github: {
+    checkStarred: (owner: string, repo: string): Promise<IpcResponse<{ starred: boolean; ghAvailable: boolean }>> =>
+      ipcRenderer.invoke('github:checkStarred', owner, repo),
+
+    toggleStar: (owner: string, repo: string, star: boolean): Promise<IpcResponse<{ starred: boolean }>> =>
+      ipcRenderer.invoke('github:toggleStar', owner, repo, star),
+  },
 };
 
 // Expose the API to the renderer process


### PR DESCRIPTION
## Summary
- Add `github:checkStarred` / `github:toggleStar` IPC handlers using `gh` CLI
- Expose GitHub API through preload context bridge
- Star button in header: ★ yellow (starred) / ☆ (not starred) with click-to-toggle
- Fallback to GitHub link when `gh` is not installed or not authenticated

## Test plan
- [ ] With `gh` authenticated: Star button shows correct state on load
- [ ] Click Star → fills yellow, click again → empties
- [ ] Without `gh`: button still shows as a GitHub link (no errors)

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)