### PR TITLE
(#89) feat: show execution timestamp in run-now result dialog

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -319,11 +319,12 @@ function App() {
 
   const handleRun = async (id: string) => {
     setRunningJobs(prev => new Set(prev).add(id));
+    const executedAt = new Date().toLocaleString();
     try {
       const response = await api.jobs.run(id);
       if (response.success && response.data) {
         const result = response.data;
-        const message = `${t('success.runCompleted')}\n\n${t('dialogs.exitCode')}: ${result.exitCode}\n\n` +
+        const message = `${t('success.runCompleted')}\n${executedAt}\n\n${t('dialogs.exitCode')}: ${result.exitCode}\n\n` +
           `${t('dialogs.stdout')}:\n${result.stdout || '(empty)'}\n\n` +
           `${t('dialogs.stderr')}:\n${result.stderr || '(empty)'}`;
         showAlert(message, 'info');


### PR DESCRIPTION
## Summary
- Show execution timestamp at the top of the Run Now result dialog
- Timestamp is captured at button-click time using `new Date().toLocaleString()`

## Test plan
- [ ] Click Run Now on any job → result dialog shows timestamp (e.g. `3/1/2026, 5:21:33 AM`)
- [ ] Timestamp reflects the actual time the button was pressed

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)