### PR TITLE
(#91) fix: add HOME env var to run-now execution environment

### DIFF
--- a/src/main/services/crontab.service.ts
+++ b/src/main/services/crontab.service.ts
@@ -708,6 +708,7 @@ export class CrontabService {
     const mergedEnv = {
       // Minimal essential vars from process
       PATH: process.env.PATH || (this.isWindows ? 'C:\\Windows\\System32' : '/usr/bin:/bin'),
+      HOME: process.env.HOME || process.env.USERPROFILE || '',
       // Global env from crontab
       ...globalEnv,
       // Job-specific env (highest priority)


### PR DESCRIPTION
## Summary

- `runJob()` 의 `mergedEnv`에 `HOME` 환경변수가 누락되어 `~/` 경로를 사용하는 명령이 즉시실행 시 exit code 2로 실패하던 문제 수정
- `process.env.HOME || process.env.USERPROFILE || ''` 추가로 Linux/Windows(WSL) 모두 동작

## Test plan

- [ ] WSL 환경에서 `echo '$(date)' >> ~/logs/echo.log 2>&1` 명령 즉시실행 확인
- [ ] 스케줄 cron 정상 동작 유지 확인

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)