### PR TITLE
(#93) fix: clear stale lock files on app startup to prevent run-now being blocked

### DIFF
--- a/src/main/services/crontab.service.ts
+++ b/src/main/services/crontab.service.ts
@@ -20,6 +20,8 @@ export class CrontabService {
 
   constructor(configService: ConfigService) {
     this.configService = configService;
+    // Clear all lock files on startup — if the app just started, no jobs can be running
+    this.clearAllLocks();
   }
 
   // ── Platform helpers ──────────────────────────────────────────────────────
@@ -681,6 +683,19 @@ export class CrontabService {
   private async releaseLock(jobId: string): Promise<void> {
     const fs = await import('fs/promises');
     await fs.unlink(this.getLockPath(jobId)).catch(() => {});
+  }
+
+  private async clearAllLocks(): Promise<void> {
+    try {
+      const fs = await import('fs/promises');
+      const path = require('path');
+      const os = require('os');
+      const lockDir = path.join(os.homedir(), '.cron-manager', 'locks');
+      const files = await fs.readdir(lockDir).catch(() => [] as string[]);
+      await Promise.all(files.filter(f => f.endsWith('.lock')).map(f => fs.unlink(path.join(lockDir, f)).catch(() => {})));
+    } catch {
+      // Ignore errors (lock dir might not exist yet)
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- 앱 시작 시 `~/.cron-manager/locks/*.lock` 파일 전체 초기화
- 앱이 예기치 않게 종료될 때 lock 파일이 남아 Run Now 버튼을 영구 차단하던 문제 수정
- 앱이 방금 시작됐으면 어떤 job도 실행 중일 수 없으므로 모든 lock 초기화가 안전함

## Test plan

- [ ] 즉시실행 중 앱 강제종료 → 재시작 후 같은 job 즉시실행 정상 동작 확인
- [ ] 정상 실행 완료 후 lock 파일 자동 삭제 확인

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)