### PR TITLE
(#95) feat: add graceful shutdown and Windows uninstaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ test-*.js
 
 .idea/
 .claude/
-.omc/
+.omc/\!build/installer.nsh

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,17 @@
+; Custom NSIS script for Cron Manager uninstaller
+; Cleans up app data on Windows and WSL when uninstalling
+
+!macro customUnInstall
+  ; Ask user whether to remove all app data
+  MessageBox MB_YESNO|MB_ICONQUESTION \
+    "Do you want to remove all Cron Manager data?$\n$\nThis includes backups, config, and lock files in:$\n  - $PROFILE\.cron-manager$\n  - WSL: ~/.cron-manager$\n$\nYour crontab jobs will NOT be removed." \
+    IDNO skip_data_removal
+
+  ; Remove Windows-side app data
+  RMDir /r "$PROFILE\.cron-manager"
+
+  ; Remove WSL-side app data (ignore errors if WSL not available)
+  nsExec::Exec '"$WINDIR\system32\wsl.exe" rm -rf ~/.cron-manager'
+
+  skip_data_removal:
+!macroend

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { Play, Trash2, Plus, RefreshCw, FolderOpen, Edit, ChevronUp, ChevronDown, Save, ListChecks, Settings, Database, Search, X, Github, Languages, Check, GripVertical, Loader2, Star } from 'lucide-react';
 import { JobForm } from './components/JobForm';
+import { UninstallDialog } from './components/UninstallDialog';
 import { LogButton } from './components/LogButton';
 import { LogViewer } from './components/LogViewer';
 import { GlobalEnvSettings } from './components/GlobalEnvSettings';
@@ -49,6 +50,7 @@ function App() {
   const [starred, setStarred] = useState<boolean | null>(null);
   const [ghAvailable, setGhAvailable] = useState<boolean>(false);
   const { showAlert } = useAlertDialog();
+  const [showUninstallDialog, setShowUninstallDialog] = useState(false);
 
   // Resizable columns for jobs table
   const { getColumnStyle, ResizeHandle } = useResizableColumns('jobs', {
@@ -104,6 +106,13 @@ function App() {
   useEffect(() => {
     checkCrontabPermission();
   }, [checkCrontabPermission]);
+
+  useEffect(() => {
+    const cleanup = window.electronAPI?.menu?.onUninstall(() => {
+      setShowUninstallDialog(true);
+    });
+    return () => cleanup?.();
+  }, []);
 
   // Check GitHub star status on app start
   useEffect(() => {
@@ -1307,6 +1316,11 @@ function App() {
           workingDir={logViewer.workingDir}
           onClose={() => setLogViewer(null)}
         />
+      )}
+
+      {/* Uninstall Dialog (Windows only) */}
+      {showUninstallDialog && (
+        <UninstallDialog onClose={() => setShowUninstallDialog(false)} />
       )}
     </div>
   );

--- a/frontend/src/components/UninstallDialog.tsx
+++ b/frontend/src/components/UninstallDialog.tsx
@@ -1,0 +1,226 @@
+import { useState } from 'react';
+import { Trash2, X, AlertTriangle } from 'lucide-react';
+import logoSvg from '/logo.svg';
+
+interface UninstallDialogProps {
+  onClose: () => void;
+}
+
+export function UninstallDialog({ onClose }: UninstallDialogProps) {
+  const [removeCrontabJobs, setRemoveCrontabJobs] = useState(false);
+  const [step, setStep] = useState<'confirm' | 'running' | 'done' | 'error'>('confirm');
+  const [log, setLog] = useState<string[]>([]);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleUninstall = async () => {
+    setStep('running');
+    setLog([]);
+
+    try {
+      // Step 1: cleanup data via IPC
+      const result = await window.electronAPI.uninstall.cleanupData({ removeCrontabJobs });
+      if (result.success && result.data) {
+        setLog(result.data);
+      }
+
+      // Step 2: launch uninstall.bat
+      await window.electronAPI.uninstall.runScript();
+
+      setStep('done');
+    } catch (err: any) {
+      setErrorMessage(err?.message || 'Uninstall failed.');
+      setStep('error');
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={step === 'confirm' ? onClose : undefined}>
+      <div
+        className="modal"
+        onClick={(e) => e.stopPropagation()}
+        style={{ maxWidth: '480px' }}
+      >
+        {/* Header */}
+        <div className="modal-header" style={{ borderBottom: 'none', paddingBottom: 0 }}>
+          <button onClick={onClose} className="modal-close" aria-label="Close" disabled={step === 'running'}>
+            <X />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div
+          style={{
+            padding: '8px 40px 28px',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '16px',
+          }}
+        >
+          {/* Logo + title */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <img src={logoSvg} alt="Cron Manager" style={{ width: 28, height: 28 }} />
+            <span style={{ fontSize: 17, fontWeight: 600, color: 'var(--text-primary)' }}>
+              Cron Manager
+            </span>
+          </div>
+
+          {/* Icon */}
+          <div style={{ color: '#ef4444' }}>
+            <Trash2 size={44} />
+          </div>
+
+          {step === 'confirm' && (
+            <>
+              <h3 style={{ margin: 0, fontSize: 19, fontWeight: 600, color: 'var(--text-primary)' }}>
+                Uninstall Cron Manager?
+              </h3>
+
+              <div style={{ fontSize: 14, color: 'var(--text-secondary)', lineHeight: 1.7, width: '100%' }}>
+                <p style={{ margin: '0 0 10px' }}>The following will be permanently removed:</p>
+                <ul style={{ margin: 0, paddingLeft: 20, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <li><code style={{ fontSize: 12 }}>%USERPROFILE%\.cron-manager</code> (backups, config, locks)</li>
+                  <li><code style={{ fontSize: 12 }}>WSL: ~/.cron-manager</code></li>
+                  <li>Electron app cache &amp; data</li>
+                  <li>Cron Manager application files</li>
+                </ul>
+              </div>
+
+              {/* Checkbox */}
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  fontSize: 13,
+                  color: 'var(--text-secondary)',
+                  cursor: 'pointer',
+                  alignSelf: 'flex-start',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={removeCrontabJobs}
+                  onChange={(e) => setRemoveCrontabJobs(e.target.checked)}
+                  style={{ width: 15, height: 15, cursor: 'pointer' }}
+                />
+                Also remove all crontab jobs managed by Cron Manager
+              </label>
+
+              {/* Warning */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: 8,
+                  background: 'rgba(239,68,68,0.08)',
+                  border: '1px solid rgba(239,68,68,0.25)',
+                  borderRadius: 8,
+                  padding: '10px 14px',
+                  fontSize: 13,
+                  color: '#ef4444',
+                  width: '100%',
+                  boxSizing: 'border-box',
+                }}
+              >
+                <AlertTriangle size={15} style={{ flexShrink: 0, marginTop: 1 }} />
+                This action cannot be undone.
+              </div>
+            </>
+          )}
+
+          {step === 'running' && (
+            <>
+              <h3 style={{ margin: 0, fontSize: 18, fontWeight: 600, color: 'var(--text-primary)' }}>
+                Removing...
+              </h3>
+              <div
+                style={{
+                  width: '100%',
+                  background: 'var(--bg-secondary)',
+                  borderRadius: 6,
+                  padding: '10px 14px',
+                  fontSize: 13,
+                  color: 'var(--text-secondary)',
+                  minHeight: 80,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 4,
+                }}
+              >
+                {log.length === 0 ? (
+                  <span>Cleaning up data...</span>
+                ) : (
+                  log.map((line, i) => <span key={i}>✓ {line}</span>)
+                )}
+              </div>
+            </>
+          )}
+
+          {step === 'done' && (
+            <>
+              <h3 style={{ margin: 0, fontSize: 18, fontWeight: 600, color: 'var(--text-primary)' }}>
+                Uninstall started
+              </h3>
+              <div style={{ fontSize: 14, color: 'var(--text-secondary)', textAlign: 'center', lineHeight: 1.7 }}>
+                App data has been removed.<br />
+                The uninstaller window should appear shortly.
+              </div>
+              {log.length > 0 && (
+                <div
+                  style={{
+                    width: '100%',
+                    background: 'var(--bg-secondary)',
+                    borderRadius: 6,
+                    padding: '10px 14px',
+                    fontSize: 12,
+                    color: 'var(--text-secondary)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 3,
+                  }}
+                >
+                  {log.map((line, i) => <span key={i}>✓ {line}</span>)}
+                </div>
+              )}
+            </>
+          )}
+
+          {step === 'error' && (
+            <>
+              <h3 style={{ margin: 0, fontSize: 18, fontWeight: 600, color: '#ef4444' }}>
+                Uninstall failed
+              </h3>
+              <div style={{ fontSize: 14, color: 'var(--text-secondary)', textAlign: 'center' }}>
+                {errorMessage}
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="modal-footer" style={{ justifyContent: 'center', gap: 10 }}>
+          {step === 'confirm' && (
+            <>
+              <button onClick={onClose} className="btn" style={{ minWidth: 100 }}>
+                Cancel
+              </button>
+              <button
+                onClick={handleUninstall}
+                className="btn btn-danger"
+                style={{ minWidth: 120, background: '#ef4444', color: '#fff', border: 'none' }}
+              >
+                Uninstall
+              </button>
+            </>
+          )}
+          {(step === 'done' || step === 'error') && (
+            <button onClick={onClose} className="btn btn-primary" style={{ minWidth: 100 }}>
+              Close
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -96,6 +96,12 @@
       "shared/dist",
       "shared/package.json"
     ],
+    "extraResources": [
+      {
+        "from": "resources/uninstall.bat",
+        "to": "uninstall.bat"
+      }
+    ],
     "asarUnpack": [
       "shared/**/*"
     ],
@@ -118,6 +124,10 @@
         "zip"
       ],
       "icon": "build/icon.ico"
+    },
+    "nsis": {
+      "include": "build/installer.nsh",
+      "deleteAppDataOnUninstall": false
     },
     "linux": {
       "target": [

--- a/resources/uninstall.bat
+++ b/resources/uninstall.bat
@@ -1,0 +1,65 @@
+@echo off
+chcp 65001 >nul
+echo.
+echo ========================================
+echo   Cron Manager Uninstaller
+echo ========================================
+echo.
+
+:: Step 1: Kill running Cron Manager process
+echo [1/5] Stopping Cron Manager...
+taskkill /F /IM "Cron Manager.exe" /T 2>nul
+if %errorlevel%==0 (
+    echo       Stopped.
+) else (
+    echo       Not running.
+)
+timeout /t 1 /nobreak >nul
+
+:: Step 2: Remove Windows-side app data
+echo [2/5] Removing Windows app data...
+if exist "%USERPROFILE%\.cron-manager" (
+    rmdir /s /q "%USERPROFILE%\.cron-manager"
+    echo       Removed: %USERPROFILE%\.cron-manager
+) else (
+    echo       Not found.
+)
+
+:: Step 3: Remove Electron app cache/data
+echo [3/5] Removing Electron app data...
+if exist "%APPDATA%\Cron Manager" (
+    rmdir /s /q "%APPDATA%\Cron Manager"
+    echo       Removed: %APPDATA%\Cron Manager
+)
+if exist "%LOCALAPPDATA%\cron-manager" (
+    rmdir /s /q "%LOCALAPPDATA%\cron-manager"
+    echo       Removed: %LOCALAPPDATA%\cron-manager
+)
+
+:: Step 4: Remove WSL-side app data
+echo [4/5] Removing WSL app data...
+where wsl >nul 2>&1
+if %errorlevel%==0 (
+    wsl rm -rf ~/.cron-manager 2>nul
+    echo       Removed: WSL ~/.cron-manager
+) else (
+    echo       WSL not available, skipping.
+)
+
+:: Step 5: Run NSIS uninstaller
+echo [5/5] Running uninstaller...
+set "UNINSTALLER=%LOCALAPPDATA%\Programs\cron-manager\Uninstall Cron Manager.exe"
+if exist "%UNINSTALLER%" (
+    echo       Launching uninstaller...
+    start "" "%UNINSTALLER%"
+) else (
+    echo       Uninstaller not found.
+    echo       Please uninstall manually via Control Panel ^> Apps.
+)
+
+echo.
+echo ========================================
+echo   Done. Cron Manager has been removed.
+echo ========================================
+echo.
+pause

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -13,7 +13,7 @@ function startVite() {
   viteProcess = spawn('npx', ['vite'], {
     cwd: rootDir,
     stdio: 'inherit',
-    shell: true,
+    detached: true,
   });
 
   viteProcess.on('exit', (code) => {
@@ -48,7 +48,9 @@ function startElectron() {
 
 function cleanup() {
   if (viteProcess) {
-    viteProcess.kill();
+    if (viteProcess.pid) {
+      try { process.kill(-viteProcess.pid, 'SIGTERM'); } catch {}
+    }
     viteProcess = null;
   }
   if (electronProcess) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,8 @@
 import { app, BrowserWindow, shell } from 'electron';
 import { join } from 'path';
-import { setupIpcHandlers } from './ipc';
+import { setupIpcHandlers, cleanupAllStreams } from './ipc';
 import { configService } from './services/config.service';
-import { initCrontabService } from './services/crontab.service';
+import { initCrontabService, crontabService } from './services/crontab.service';
 import { createApplicationMenu } from './menu';
 
 const isDev = process.env.NODE_ENV === 'development';
@@ -71,6 +71,14 @@ app.whenReady().then(async () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createWindow();
     }
+  });
+});
+
+app.on('will-quit', (event) => {
+  event.preventDefault();
+  cleanupAllStreams();
+  (crontabService?.flush() ?? Promise.resolve()).finally(() => {
+    app.exit(0);
   });
 });
 

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1,4 +1,4 @@
-import { ipcMain, shell, BrowserWindow } from 'electron';
+import { ipcMain, shell, BrowserWindow, app } from 'electron';
 import { spawn, exec } from 'child_process';
 import { promisify } from 'util';
 import type { ChildProcess } from 'child_process';
@@ -774,4 +774,84 @@ export function setupIpcHandlers(config?: { htmlPath?: string }) {
       return { success: false, error: error.message };
     }
   });
+
+  // Uninstall: clean up app data (Windows only)
+  ipcMain.handle('uninstall:cleanupData', async (_, options: { removeCrontabJobs: boolean }) => {
+    try {
+      const fs = await import('fs-extra');
+      const pathMod = await import('path');
+      const results: string[] = [];
+
+      // 1. Optionally remove CRON-MANAGER jobs from crontab
+      if (options.removeCrontabJobs) {
+        try {
+          const content = await crontabService.readCrontab();
+          const lines = content.split('\n');
+          const cleaned: string[] = [];
+          let skipNext = false;
+          for (const line of lines) {
+            if (line.startsWith('# CRON-MANAGER:')) {
+              skipNext = true;
+              continue;
+            }
+            if (skipNext && line.trim() !== '') {
+              skipNext = false;
+              continue;
+            }
+            skipNext = false;
+            cleaned.push(line);
+          }
+          // Remove trailing empty lines
+          while (cleaned.length > 0 && cleaned[cleaned.length - 1].trim() === '') {
+            cleaned.pop();
+          }
+          await crontabService.writeCrontab(cleaned.join('\n'));
+          await crontabService.flush();
+          results.push('Crontab jobs removed');
+        } catch (e: any) {
+          results.push(`Crontab cleanup failed: ${e.message}`);
+        }
+      }
+
+      // 2. Remove Windows-side app data
+      const winDataDir = pathMod.join(os.homedir(), '.cron-manager');
+      if (await fs.pathExists(winDataDir)) {
+        await fs.remove(winDataDir);
+        results.push('Windows app data removed');
+      }
+
+      // 3. Remove WSL-side app data
+      try {
+        await execAsync('wsl rm -rf ~/.cron-manager');
+        results.push('WSL app data removed');
+      } catch {
+        // WSL not available or already removed — ignore
+      }
+
+      return { success: true, data: results };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  // Uninstall: run embedded uninstall.bat
+  ipcMain.handle('uninstall:runScript', async () => {
+    try {
+      const batPath = app.isPackaged
+        ? path.join(process.resourcesPath, 'uninstall.bat')
+        : path.join(__dirname, '../../../resources/uninstall.bat');
+
+      spawn('cmd.exe', ['/c', 'start', '', batPath], { detached: true, stdio: 'ignore' }).unref();
+      return { success: true };
+    } catch (error: any) {
+      return { success: false, error: error.message };
+    }
+  });
+}
+
+export function cleanupAllStreams() {
+  for (const proc of activeTailProcesses.values()) {
+    proc.kill();
+  }
+  activeTailProcesses.clear();
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -140,6 +140,17 @@ export function createApplicationMenu(mainWindow: BrowserWindow) {
             await shell.openExternal('https://github.com/seunggabi/cron-manager/issues');
           },
         },
+        ...(process.platform === 'win32'
+          ? [
+              { type: 'separator' as const },
+              {
+                label: 'Uninstall Cron Manager...',
+                click: () => {
+                  mainWindow.webContents.send('menu:uninstall');
+                },
+              },
+            ]
+          : []),
       ],
     },
   ];

--- a/src/main/services/crontab.service.ts
+++ b/src/main/services/crontab.service.ts
@@ -258,6 +258,20 @@ export class CrontabService {
   }
 
   /**
+   * Flush any pending (throttled) crontab write immediately
+   */
+  async flush(): Promise<void> {
+    if (this.pendingWrite && this.pendingContent) {
+      clearTimeout(this.pendingWrite);
+      this.pendingWrite = null;
+      const content = this.pendingContent;
+      this.pendingContent = null;
+      await this.doWriteCrontab(content);
+      this.lastWriteTime = Date.now();
+    }
+  }
+
+  /**
    * Internal method to actually write crontab
    */
   private async doWriteCrontab(content: string): Promise<void> {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -173,6 +173,24 @@ const api = {
     toggleStar: (owner: string, repo: string, star: boolean): Promise<IpcResponse<{ starred: boolean }>> =>
       ipcRenderer.invoke('github:toggleStar', owner, repo, star),
   },
+
+  // Uninstall API (Windows only)
+  uninstall: {
+    cleanupData: (options: { removeCrontabJobs: boolean }): Promise<IpcResponse<string[]>> =>
+      ipcRenderer.invoke('uninstall:cleanupData', options),
+
+    runScript: (): Promise<IpcResponse<void>> =>
+      ipcRenderer.invoke('uninstall:runScript'),
+  },
+
+  // Menu events
+  menu: {
+    onUninstall: (callback: () => void) => {
+      const handler = () => callback();
+      ipcRenderer.on('menu:uninstall', handler);
+      return () => ipcRenderer.removeListener('menu:uninstall', handler);
+    },
+  },
 };
 
 // Expose the API to the renderer process


### PR DESCRIPTION
## Summary
- Add graceful shutdown: cleanup tail processes and flush pending crontab writes on app exit
- Fix dev-runner Vite process not terminating on exit (shell:true → detached + process group kill)
- Add Windows uninstaller: embedded `uninstall.bat`, NSIS custom script, IPC handlers, and Uninstall dialog

## Changes
- `src/main/ipc/index.ts`: export `cleanupAllStreams()`, add `uninstall:cleanupData` / `uninstall:runScript` IPC handlers
- `src/main/services/crontab.service.ts`: add `flush()` to immediately write pending throttled crontab
- `src/main/index.ts`: add `will-quit` handler — cleanup streams + flush before `app.exit(0)`
- `scripts/dev-runner.ts`: `shell: true` → `detached: true`, cleanup uses `process.kill(-pid)`
- `src/main/menu.ts`: add "Uninstall Cron Manager..." to Help menu (Windows only)
- `src/preload/index.ts`: expose `uninstall` and `menu` APIs to renderer
- `frontend/src/components/UninstallDialog.tsx`: 3-step dialog (confirm → running → done)
- `frontend/src/App.tsx`: integrate UninstallDialog with `menu:uninstall` IPC event
- `resources/uninstall.bat`: 5-step uninstall script bundled in app resources
- `build/installer.nsh`: NSIS custom script to clean up data on Windows uninstall

## Test plan
- [ ] Close app window → verify no orphan Vite or tail processes remain
- [ ] Ctrl+C in dev mode → verify Vite process group fully terminates
- [ ] Windows: Help > Uninstall Cron Manager... → dialog appears
- [ ] Check "remove crontab jobs" → verify crontab is cleaned
- [ ] Uninstall button → bat script launches, NSIS uninstaller opens

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)