### PR TITLE
(#97) fix: make clearAllLocks synchronous to prevent run-now race condition

### DIFF
--- a/src/main/services/crontab.service.ts
+++ b/src/main/services/crontab.service.ts
@@ -699,14 +699,19 @@ export class CrontabService {
     await fs.unlink(this.getLockPath(jobId)).catch(() => {});
   }
 
-  private async clearAllLocks(): Promise<void> {
+  private clearAllLocks(): void {
     try {
-      const fs = await import('fs/promises');
+      const fs = require('fs');
       const path = require('path');
       const os = require('os');
       const lockDir = path.join(os.homedir(), '.cron-manager', 'locks');
-      const files = await fs.readdir(lockDir).catch(() => [] as string[]);
-      await Promise.all(files.filter(f => f.endsWith('.lock')).map(f => fs.unlink(path.join(lockDir, f)).catch(() => {})));
+      if (!fs.existsSync(lockDir)) return;
+      const files: string[] = fs.readdirSync(lockDir);
+      for (const f of files) {
+        if (f.endsWith('.lock')) {
+          try { fs.unlinkSync(path.join(lockDir, f)); } catch {}
+        }
+      }
     } catch {
       // Ignore errors (lock dir might not exist yet)
     }


### PR DESCRIPTION
## Summary
- Convert `clearAllLocks()` from async to synchronous using `readdirSync`/`unlinkSync`
- Ensures stale lock files are removed before constructor returns, eliminating race condition
- Fixes intermittent run-now failure after app restart or reinstall

## Root Cause
When the app force-exits while a job is running, `app.exit(0)` skips the `finally` block in `runJob`, leaving a stale lock file. On next startup, the old async `clearAllLocks()` was not awaited in the constructor — so if the user clicked run-now before cleanup completed, `acquireLock()` found the stale lock (within 5-min TTL) and threw "Job is already running".

## Test plan
- [ ] Run a job via run-now, force-quit the app while it's executing
- [ ] Reopen the app and immediately click run-now — should work without "already running" error
- [ ] Verify normal run-now execution still works

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)